### PR TITLE
CI: Lint, Fix linter warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  mypy:
-    name: mypy ${{ matrix.py }} on ${{ matrix.os }}
+  lint:
+    name: Lint ${{ matrix.py }} on ${{ matrix.os }}
 
     strategy:
       matrix:
@@ -14,7 +14,7 @@ jobs:
           - windows-latest  # WindowsPath
           - ubuntu-latest  # PosixPath
         py:
-          - "3.8"  # oldest working
+          #- "3.8"  # oldest we support, fails to install requirements now
           - "3.10"  # oldest with upstream support
           - "3.14"  # newest supported
           #- "3.15-dev"  # next
@@ -31,12 +31,15 @@ jobs:
         shell: bash
         run: |
           python -m pip install -U pip
-          python -m pip install -U -r requirements.txt
-          python -m pip install -U mypy certifi types-certifi types-jsonschema
+          python -m pip install '.[lint]'
       - name: Run mypy
         shell: bash
         run: |
           python -m mypy --strict pack_checker
+      - name: Run flake8
+        shell: bash
+        run: |
+          python -m flake8 pack_checker pack_checker.py
 
   check-example-pack:
     name: Check examples with py${{ matrix.py }} on ${{ matrix.os }}

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -366,10 +366,15 @@ def check(path: Path,
 
     @cached  # we cache here since registry is immutable
     def retrieve(uri: str) -> Resource[Any]:
+        if uri.startswith("file:"):
+            raise ValueError("File URI not allowed in schema")
         if "://" in uri or uri.startswith("/"):
-            raise NotImplementedError()
+            raise NotImplementedError()  # only relative retrieve implemented
         full_uri = schema_src + uri
-        r = urlopen(full_uri)
+        # TODO: deny insecure http in v2
+        if not any(full_uri.startswith(schema) for schema in ("file:", "https:", "http:")):
+            raise ValueError("Unsupported URI scheme to retrieve resource")
+        r = urlopen(full_uri)  # noqa: S310 checked above
         content = r.read().decode(r.headers.get_content_charset() or "utf-8")
         return Resource.from_contents(json.loads(content),
                                       default_specification=DRAFT202012)

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -54,7 +54,6 @@ def try_configure_https() -> None:
 if "CI" not in os.environ or not os.environ["CI"]:
     import warnings
 
-
     def warn(message: str, filename: Any = None, row: Optional[int] = None, col: int = 0) -> None:
         if filename is not None and row is not None:
             warnings.warn(f"{filename}[{row}:{col}]: {message}")
@@ -93,7 +92,7 @@ def pack_path(s: str) -> Path:
         return Path(s)
     if os.path.isfile(s) and s.lower().endswith(".zip"):
         return Path(s)
-    raise argparse.ArgumentTypeError(f"Given argument is not a pack")
+    raise argparse.ArgumentTypeError("Given argument is not a pack")
 
 
 def schema_uri(s: str) -> str:
@@ -108,7 +107,7 @@ def schema_uri(s: str) -> str:
 
 
 def find_entry_point(path: Path, checks: Mapping[str, bool]) -> ZipPath:
-    assert path.is_file()
+    assert path.is_file()  # noqa: S101 debug message, would fail in the line below anyway
     zippath = ZipPath(path)
     warn_for_hidden_files = checks.get("hidden_files", False)
     # find starting point inside the zip and check for hidden files
@@ -182,7 +181,6 @@ def identify_json(name: str, stream: TextIO, variants: List[str]) -> Optional[It
 if PY < (3, 12):
     from fnmatch import fnmatch, fnmatchcase
 
-
     def _rglob_case(path: Path, pattern: str, case_sensitive: Optional[bool] = None, *args: Any, **kwargs: Any
                     ) -> Generator[Path, None, None]:
         if case_sensitive is None:
@@ -200,7 +198,6 @@ if PY < (3, 12):
             for candidate in candidates:
                 if fnmatch(str(candidate).lower(), pattern):
                     yield candidate
-
 
     _original_rglob = Path.rglob
     Path.rglob = _rglob_case  # type: ignore[method-assign,assignment]
@@ -228,7 +225,7 @@ class _CollectJson(Generic[APath]):
                 pos = 0
                 while warn_for_legacy_incompatibility:
                     block = bin_stream.read(4096)
-                    assert isinstance(block, bytes)
+                    assert isinstance(block, bytes)  # noqa: S101 for type checker
                     if not block:
                         warn("JSON files appears to be empty.", f, 0)
                         break

--- a/pack_checker/ziputil.py
+++ b/pack_checker/ziputil.py
@@ -27,7 +27,8 @@ class ZipPath(zipfile.Path):
         return cast(ZipPath, res)
 
     def relative_to(self, other: zipfile.Path, *extra: Union[str, "os.PathLike[str]"]) -> str:
-        assert not extra, "extra for ZipPath.relative_to not implemented"
+        if extra:
+            raise NotImplementedError("extra for ZipPath.relative_to not implemented")
         return self._relative_to(str(self), str(other))
 
     def iterdir(self) -> Iterator["ZipPath"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,12 @@ cli = [
 ]
 lint = [
   "types-jsonschema>=4.20.0.20240105",
-  "certifi",
+  "certifi>=2026.2.25",
+  "mypy==1.19.1",
+  "flake8==7.3.0",
+  "bandit==1.9.4",
+  "flake8-bandit==4.1.1",
+  "flake8-pyproject==1.2.4",
 ]
 
 [project.urls]
@@ -39,3 +44,8 @@ Issues = "https://github.com/PopTracker/pack-checker/issues"
 
 [project.scripts]
 pack-checker = "pack_checker.cli:main"
+
+[tool.flake8]
+doctests = true
+max-line-length = 120
+max-complexity = 39  # TODO: get this down to ~15


### PR DESCRIPTION
* Update pyproject and CI workflow to run flake8 and flake8-bandit
* Update CI workflow to install requirements from pyproject
  * Use exact versions for flake8, bandit and mypy so errors are reproducible
* Drop py3.8 for linting - py3.8 still works for the actual program, just not the dev tools
* Remove outdated types-certifi from CI workflow
* Provide useful errors if the user requested an unexpected URI scheme for `--schema`
* Replace an assert with a NotImplementedError in ziputil to make sure it'd behave the same between debug and release
* Fix or silence remaining linter warnings