### PR TITLE
CI: workflow updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,14 +10,13 @@ jobs:
 
     strategy:
       matrix:
-        os:
-          - windows-latest  # WindowsPath
-          - ubuntu-latest  # PosixPath
-        py:
-          #- "3.8"  # oldest we support, fails to install requirements now
-          - "3.10"  # oldest with upstream support
-          - "3.14"  # newest supported
-          #- "3.15-dev"  # next
+        include:
+          - os: ubuntu-latest
+            py: "3.10"  # oldest supported for dev
+          - os: ubuntu-latest
+            py: "3.14"  # newest supported, PosixPath
+          - os: windows-latest
+            py: "3.14"  # newest supported, WindowsPath
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -55,6 +54,8 @@ jobs:
             py: "3.8"  # oldest working
           - os: windows-latest
             py: "3.14"  # newest supported
+          #- os: ubuntu-latest
+          #  py: "3.15-dev"  # next
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,14 @@ on:
         type: boolean
 
 jobs:
+  ci:  # make sure CI passes before releasing
+    uses: ./.github/workflows/ci.yaml
+
+
   release:
     name: Release for ${{ matrix.os }}
+    needs:
+      - ci  # NOTE: publish waits for release, so we only need to wait for ci here
 
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,8 +51,8 @@ jobs:
       - name: Build exe
         shell: bash
         run: |
-          python -m pip install -U -r requirements.txt
-          python -m pip install -U pyinstaller certifi
+          python -m pip install -U pip
+          python -m pip install -U -r requirements.txt -r requirements_exe.txt
           python -m PyInstaller -F pack_checker.py
           cp README* dist/
           mkdir rls

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+    # also test workflow when changed:
+    branches:
+      - "*"
+    paths:
+      - ".github/workflows/release.yaml"
+      - "requirements_exe.txt"
   workflow_dispatch:
     inputs:
       test_pypi:
@@ -11,6 +17,7 @@ on:
 
 jobs:
   ci:  # make sure CI passes before releasing
+    if: startsWith(github.ref, 'refs/tags/')  # only create release on tag pushes
     uses: ./.github/workflows/ci.yaml
 
 
@@ -18,6 +25,9 @@ jobs:
     name: Release for ${{ matrix.os }}
     needs:
       - ci  # NOTE: publish waits for release, so we only need to wait for ci here
+    if: |
+      always()
+      && !contains(needs.*.result, 'failure')
 
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,13 +61,18 @@ jobs:
         shell: bash
         run: |
           cd dist
-          7z a -mx=9 "../rls/pack-checker_${{ env.RELEASE_NAME }}_${{ matrix.name }}.zip" *
+          7z a -mx=9 "../rls/pack-checker_${{ env.RELEASE_NAME }}_${{ matrix.name }}.zip" -- *
       - name: TAR GZ
         if: ${{ runner.os != 'Windows' }}
         shell: bash
         run: |
           cd dist
-          tar -czvf "../rls/pack-checker_${{ env.RELEASE_NAME }}_${{ matrix.name }}.tar.gz" *
+          tar -czvf "../rls/pack-checker_${{ env.RELEASE_NAME }}_${{ matrix.name }}.tar.gz" -- *
+      - name: Store Build
+        uses: actions/upload-artifact@v7
+        with:
+          path: "rls/*"
+          archive: false
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')  # only create release on tag pushes
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/requirements_exe.txt
+++ b/requirements_exe.txt
@@ -1,0 +1,3 @@
+# specific requirements we use during CI to create an EXE
+pyinstaller==6.19.0
+certifi==2026.2.25


### PR DESCRIPTION
* use specific configurations for lint
* rerun CI (tests) in release workflow
* test/dry run release workflow when it changed
* use specific version of pyinstaller, move that to requirements_exe.txt
* store pyinstaller output