### PR TITLE
Promote unmatched file to warning, match and validate .luarc.json

### DIFF
--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os.path
 import typing as t
+import warnings
 
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Union
@@ -20,7 +21,10 @@ from . import __version__
 from .collect import Item, collect_images, collect_json, collect_lua
 from .datachecks import check_refs, DataCheckError
 from .imgutil import supported_formats as supported_img_formats
-from .ziputil import ZipPath
+from .warnings import warn_pack, cli_warnings_formatter_context
+
+warn = warn_pack  # re-export for back compat. Remove at 2.0
+
 
 schema_default_src = "https://poptracker.github.io/schema/packs/"
 schema_names = ["items", "layouts", "locations", "manifest", "maps", "settings", "classes"]
@@ -47,44 +51,6 @@ def try_configure_https() -> None:
         urllib.request.install_opener(opener)
     except ImportError:
         pass
-
-
-if "CI" not in os.environ or not os.environ["CI"]:
-    import warnings
-
-    def warn(message: str, filename: Any = None, row: Optional[int] = None, col: int = 0) -> None:
-        if filename is not None and row is not None:
-            warnings.warn(f"{filename}[{row}:{col}]: {message}")
-        elif filename is not None:
-            warnings.warn(f"{filename}: {message}")
-        else:
-            warnings.warn(message)
-
-else:
-
-    def warn(message: str, filename: Any = None, row: Optional[int] = None, col: int = 0) -> None:
-        physical_filename: Optional[str]
-        message_file_marker: str
-        if filename is not None:
-            message_file_marker = f"%0Ain {filename}"
-            if row is not None:
-                message_file_marker += f" at {col}:{row}"
-            if isinstance(filename, (str, Path)) and os.path.exists(filename):
-                physical_filename = str(filename)
-            elif isinstance(filename, ZipPath) and os.path.exists(str(getattr(filename, "root"))):
-                physical_filename = str(getattr(filename, "root"))
-                row = None
-            else:
-                physical_filename = None
-        else:
-            physical_filename = None
-            message_file_marker = ""
-        if physical_filename and row is not None:
-            print(f"::warning file={filename},line={row},col={col}::{message}{message_file_marker}")
-        elif physical_filename:
-            print(f"::warning file={filename}::{message}{message_file_marker}")
-        else:
-            print(f"::warning::{message}{message_file_marker}")
 
 
 def pack_path(s: str) -> Path:
@@ -190,10 +156,12 @@ def check(
                 print(f"{json_item.name}: {json_item.data}")
                 ok = False
             elif json_item.type is None:
-                print(f"Unmatched file: {json_item.name}")
+                warn_pack("Unmatched file", filename=json_item.name)
             else:
-                print("No schema {item.type} for {item.name}")
+                warnings.warn(f"No schema {json_item.type} for {json_item.name}", RuntimeWarning)
                 ok = False
+    except ImportError:
+        raise
     except Exception as ex:
         print(f"Error collecting json: {ex}")
         return False
@@ -205,7 +173,7 @@ def check(
         for lua_item in collect_lua(path, checks):  # collecting them checks for encoding errors
             # do we want to bundle a full Lua? py-lua-parser is sadly not good enough
             if lua_item.type == "error":
-                warn(str(lua_item.data), lua_item.name)
+                warn_pack(str(lua_item.data), lua_item.name)
                 # ok = False  # TODO: enable this in v2
     except Exception as ex:
         print(f"Error collecting Lua: {ex}")
@@ -219,11 +187,11 @@ def check(
             # until we verify the image is actually in use, only report compatibility issues for zip
             # since a folder could have source files that then get converted to the format in use
             if image_item.type == "error":
-                warn(str(image_item.data), image_item.name)
+                warn_pack(str(image_item.data), image_item.name)
                 # ok = False  # TODO: enable this in v2
             elif is_zipped:
                 if image_item.type not in supported_img_formats:
-                    warn(f"Image format {image_item.type} is not supported by all versions", image_item.name)
+                    warn_pack(f"Image format {image_item.type} is not supported by all versions", image_item.name)
     except Exception as ex:
         print(f"Error collecting images: {ex}")
         return False
@@ -238,14 +206,14 @@ def check(
         try:
             if tuple(map(int, min_poptracker_version.split("."))) < (0, 24, 1):
                 required_min_poptracker_version_string = ".".join(map(str, required_min_poptracker_version))
-                warn(
+                warn_pack(
                     f'min_poptracker_version should be at least "{required_min_poptracker_version_string}" '
                     "(this does not detect all features yet).",
                     manifest.name,
                 )
         except (ValueError, AttributeError):
             reason = "Pack requires poptracker" if requires_poptracker else "Legacy mode is off"
-            warn(f"{reason}, but min_poptracker_version is not set to a valid version.", manifest.name)
+            warn_pack(f"{reason}, but min_poptracker_version is not set to a valid version.", manifest.name)
 
     return count if ok else 0
 
@@ -256,7 +224,8 @@ def run(args: argparse.Namespace) -> int:
         **default_checks,
         "legacy_compat": args.legacy_compat,
     }
-    res = check(args.path, args.schema if args.schema else schema_default_src, args.strict, checks)
+    with cli_warnings_formatter_context():
+        res = check(args.path, args.schema if args.schema else schema_default_src, args.strict, checks)
     if res:
         print(f"Validated {res} files")
     if args.interactive:

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -219,8 +219,7 @@ def check(
         print(f"Error collecting json: {ex}")
         return False
     finally:
-        if is_zipped:
-            checks = {**checks, "hidden_files": False}  # only check the first time zip is inspected
+        checks = {**checks, "hidden_files": False}  # only check hidden once
 
     try:
         for lua_item in collect_lua(path, checks):  # collecting them checks for encoding errors
@@ -231,9 +230,6 @@ def check(
     except Exception as ex:
         print(f"Error collecting Lua: {ex}")
         return False
-    finally:
-        if is_zipped:
-            checks = {**checks, "hidden_files": False}  # only check the first time zip is inspected
 
     try:
         for image_item in collect_images(path, checks):
@@ -248,9 +244,6 @@ def check(
     except Exception as ex:
         print(f"Error collecting images: {ex}")
         return False
-    finally:
-        if is_zipped:
-            checks = {**checks, "hidden_files": False}  # only check the first time zip is inspected
 
     if manifest and (requires_poptracker or not checks.get("legacy_compat", True)):
         # if either legacy compat is off, or poptracker is required, check min_pop_version is sensible

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -33,7 +33,10 @@ external_schema = {
     ".luarc": {
         "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
         "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-    }
+    },
+    "versions": {
+        "https://raw.githubusercontent.com/black-sliver/PopTracker/refs/heads/packlist/schema/versions.schema.json"
+    },
 }
 allowed_external_schema = set(chain(*external_schema.values()))
 
@@ -139,7 +142,14 @@ def check(
     def validate_json_item(item: Item) -> bool:
         try:
             if item.type in external_schema:
-                schema_ref = item.data.get("$schema", None)
+                # check $schema, allow undefined/missing $schema if the expected schema is unambiguous
+                possible_schemas = external_schema[item.type]
+                first_schema = next(iter(possible_schemas))
+                schema_ref = (
+                    first_schema
+                    if not isinstance(item.data, dict) and len(possible_schemas) == 1
+                    else item.data.get("$schema", first_schema if len(external_schema[item.type]) == 1 else None)
+                )
                 if not schema_ref or schema_ref not in external_schema[item.type]:
                     raise ValidationError("Unexpected $schema")
                 validate(
@@ -148,6 +158,7 @@ def check(
                     registry=registry,
                 )
             else:
+                # validate against pack schema
                 validate(
                     instance=item.data,
                     schema={"$ref": f"strict/{item.type}.json" if strict else f"{item.type}.json"},

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -84,7 +84,7 @@ def _validate_config() -> None:
     # sanity check lists; doing this during runtime in case they get extended
     if not schema_names.isdisjoint(external_schema):
         raise ValueError("schema_names and external_schema overlap")
-    for special_name in ("error",):
+    for special_name in ("error", "ignore"):
         if special_name in schema_names or special_name in external_schema:
             raise ValueError(f"'{special_name}' has special meaning and is invalid as schema name")
 
@@ -192,7 +192,7 @@ def check(
                         manifest = json_item
                 else:
                     ok = False
-            elif is_external:
+            elif json_item.type == "ignore" or is_external:
                 pass
             elif json_item.type == "error":
                 print(f"{json_item.name}: {json_item.data}")

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -6,6 +6,7 @@ import os.path
 import typing as t
 import warnings
 
+from itertools import chain
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Union
 from urllib.parse import urlparse
@@ -28,6 +29,13 @@ warn = warn_pack  # re-export for back compat. Remove at 2.0
 
 schema_default_src = "https://poptracker.github.io/schema/packs/"
 schema_names = ["items", "layouts", "locations", "manifest", "maps", "settings", "classes"]
+external_schema = {
+    ".luarc": {
+        "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+        "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+    }
+}
+allowed_external_schema = set(chain(*external_schema.values()))
 
 default_checks: Mapping[str, bool] = {
     "legacy_compat": True,
@@ -99,8 +107,11 @@ def check(
         if uri.startswith("file:"):
             raise ValueError("File URI not allowed in schema")
         if "://" in uri or uri.startswith("/"):
-            raise NotImplementedError()  # only relative retrieve implemented
-        full_uri = schema_src + uri
+            if uri not in allowed_external_schema:
+                raise NotImplementedError()  # only relative retrieve and allow-list implemented
+            full_uri = uri
+        else:
+            full_uri = schema_src + uri
         # TODO: deny insecure http in v2
         if not any(full_uri.startswith(schema) for schema in ("file:", "https:", "http:")):
             raise ValueError("Unsupported URI scheme to retrieve resource")
@@ -112,20 +123,33 @@ def check(
 
     def validate_json_item(item: Item) -> bool:
         try:
-            validate(
-                instance=item.data,
-                schema={"$ref": f"strict/{item.type}.json" if strict else f"{item.type}.json"},
-                registry=registry,
-            )
-            for data_check in data_checks.get(item.type, []):
-                data_check(item.data, path)
+            if item.type in external_schema:
+                schema_ref = item.data.get("$schema", None)
+                if not schema_ref or schema_ref not in external_schema[item.type]:
+                    raise ValidationError("Unexpected $schema")
+                validate(
+                    instance=item.data,
+                    schema={"$ref": schema_ref},
+                    registry=registry,
+                )
+            else:
+                validate(
+                    instance=item.data,
+                    schema={"$ref": f"strict/{item.type}.json" if strict else f"{item.type}.json"},
+                    registry=registry,
+                )
+                for data_check in data_checks.get(item.type, []):
+                    data_check(item.data, path)
             return True
         except ValidationError as ex:
             print(f"\n{item.name}: {ex}")
         except DataCheckError as ex:
             print(f"\n{item.name}: {ex}")
         except Unresolvable as ex:
-            msg = f"Error loading schema {'strict/' if strict else ''}{item.type}.json: {ex}"
+            if item.type in external_schema:
+                msg = f"Error loading schema {item.data.get('$schema', None)}: {ex}"
+            else:
+                msg = f"Error loading schema {'strict/' if strict else ''}{item.type}.json: {ex}"
             raise Exception(msg) from ex
         except Exception as ex:
             print(f"{ex} while handling {item.name} {type(ex)}")
@@ -145,7 +169,7 @@ def check(
 
     try:
         for json_item in collect_json(path, checks):
-            if json_item.type in schema_names:
+            if json_item.type in schema_names or json_item.type in external_schema:
                 if validate_json_item(json_item):
                     count += 1
                     if json_item.type == "manifest":

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -186,7 +186,7 @@ def check(
     count = 0
     is_zipped = path.is_file()
     if is_zipped:
-        checks = {**checks, "hidden_files": True}
+        checks = {**checks, "hidden_files": True, "unused_files": True}
 
     # NOTE: PopTracker min version detection is not fully implemented yet
     requires_poptracker = False  # set if we detect an unconditional feature that is only available in PopTracker
@@ -219,7 +219,7 @@ def check(
         print(f"Error collecting json: {ex}")
         return False
     finally:
-        checks = {**checks, "hidden_files": False}  # only check hidden once
+        checks = {**checks, "hidden_files": False, "unused_files": False}  # only check hidden/unused once
 
     try:
         for lua_item in collect_lua(path, checks):  # collecting them checks for encoding errors

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -28,7 +28,7 @@ warn = warn_pack  # re-export for back compat. Remove at 2.0
 
 
 schema_default_src = "https://poptracker.github.io/schema/packs/"
-schema_names = ["items", "layouts", "locations", "manifest", "maps", "settings", "classes"]
+schema_names = {"items", "layouts", "locations", "manifest", "maps", "settings", "classes"}
 external_schema = {
     ".luarc": {
         "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
@@ -80,9 +80,20 @@ def schema_uri(s: str) -> str:
         return f"file://{s}/"
 
 
+def _validate_config() -> None:
+    # sanity check lists; doing this during runtime in case they get extended
+    if not schema_names.isdisjoint(external_schema):
+        raise ValueError("schema_names and external_schema overlap")
+    for special_name in ("error",):
+        if special_name in schema_names or special_name in external_schema:
+            raise ValueError(f"'{special_name}' has special meaning and is invalid as schema name")
+
+
 def check(
     path: Path, schema_src: str = schema_default_src, strict: bool = False, checks: Mapping[str, bool] = default_checks
 ) -> int:
+    _validate_config()
+
     resource_cache: Dict[str, Union[Exception, Resource[Any]]] = {}
 
     def cached(f: Callable[[str], Resource[Any]]) -> Callable[[str], Resource[Any]]:

--- a/pack_checker/cli.py
+++ b/pack_checker/cli.py
@@ -90,7 +90,11 @@ def _validate_config() -> None:
 
 
 def check(
-    path: Path, schema_src: str = schema_default_src, strict: bool = False, checks: Mapping[str, bool] = default_checks
+    path: Path,
+    schema_src: str = schema_default_src,
+    strict: bool = False,
+    checks: Mapping[str, bool] = default_checks,
+    validate_external: bool = False,
 ) -> int:
     _validate_config()
 
@@ -180,13 +184,16 @@ def check(
 
     try:
         for json_item in collect_json(path, checks):
-            if json_item.type in schema_names or json_item.type in external_schema:
+            is_external = json_item.type in external_schema
+            if json_item.type in schema_names or (validate_external and is_external):
                 if validate_json_item(json_item):
                     count += 1
                     if json_item.type == "manifest":
                         manifest = json_item
                 else:
                     ok = False
+            elif is_external:
+                pass
             elif json_item.type == "error":
                 print(f"{json_item.name}: {json_item.data}")
                 ok = False
@@ -259,8 +266,11 @@ def run(args: argparse.Namespace) -> int:
         **default_checks,
         "legacy_compat": args.legacy_compat,
     }
+    validate_external: bool = getattr(args, "validate_external", False)  # getattr since run is "public" in 1.x
     with cli_warnings_formatter_context():
-        res = check(args.path, args.schema if args.schema else schema_default_src, args.strict, checks)
+        res = check(
+            args.path, args.schema if args.schema else schema_default_src, args.strict, checks, validate_external
+        )
     if res:
         print(f"Validated {res} files")
     if args.interactive:
@@ -309,6 +319,19 @@ def main(args: Optional[t.Sequence[str]] = None) -> None:
         action="store_false",
         dest="interactive",
         help="exit program when done (default on non-Windows)",
+    )
+    external_group = parser.add_mutually_exclusive_group()
+    external_group.add_argument(
+        "--validate-external",
+        action="store_true",
+        dest="validate_external",
+        help="allow validation of select known external schemas (will become default in 2.x)",
+    )
+    external_group.add_argument(
+        "--no-validate-external",
+        action="store_false",
+        dest="validate_external",
+        help="do not validate known external schema (default)",
     )
     sys.exit(run(parser.parse_args(args)))
 

--- a/pack_checker/collect.py
+++ b/pack_checker/collect.py
@@ -148,7 +148,7 @@ class _CollectJson(t.Generic[APath]):
                     block = bin_stream.read(4096)
                     assert isinstance(block, bytes)  # noqa: S101 for type checker
                     if not block:
-                        warn_pack("JSON files appears to be empty.", f, 0)
+                        warn_pack("JSON file appears to be empty.", f, 0)
                         break
                     orig_block_len = len(block)
                     block = block.lstrip()

--- a/pack_checker/collect.py
+++ b/pack_checker/collect.py
@@ -14,6 +14,8 @@ APath = t.TypeVar("APath", Path, ZipPath)
 
 Item = namedtuple("Item", "name type data")
 
+json_ignore_prefixes = (".vs/", ".vscode/")
+
 
 def find_entry_point(path: Path, checks: t.Mapping[str, bool]) -> ZipPath:
     from .warnings import warn_pack
@@ -68,6 +70,11 @@ def read_manifest(path: APath) -> t.Tuple[t.Dict[str, t.Any], t.List[str]]:
 def identify_json(name: str, stream: t.TextIO, variants: t.List[str]) -> t.Optional[Item]:
     if not variants:
         raise ValueError("default variant missing from variants")
+
+    for ignore_prefix in json_ignore_prefixes:
+        if name.startswith(ignore_prefix):
+            return Item(name, "ignore", None)
+
     try:
         data = parse_jsonc(stream.read(), name)
     except JsonParserError as ex:

--- a/pack_checker/collect.py
+++ b/pack_checker/collect.py
@@ -138,11 +138,14 @@ class _CollectJson(t.Generic[APath]):
         self.path = path
 
     def __call__(self, checks: t.Mapping[str, bool]) -> t.Generator[Item, None, None]:
+        from .cli import external_schema
         from .warnings import warn_pack
 
         path = self.path
         manifest, variants = read_manifest(path)
         warn_for_legacy_incompatibility = checks.get("legacy_compat", True)
+        warn_for_unused_files = checks.get("unused_files", False)
+        unused_json: t.List[str] = []
 
         for f in path.rglob("*.json*", case_sensitive=False):  # type: ignore[call-arg,unused-ignore]
             name = str(f.relative_to(path)).replace("\\", "/")
@@ -176,10 +179,17 @@ class _CollectJson(t.Generic[APath]):
                     item = identify_json(name, t.cast(t.TextIO, stream), variants)
                     if item:
                         yield item
+                        # TODO: move this to a separate thing and also warn for unused other files, not just JSON
+                        if warn_for_unused_files:
+                            if (item.type == "ignore" or item.type in external_schema) and not name.startswith("."):
+                                unused_json.append(item.name)
                     else:
                         yield Item(name, None, None)
                 except Exception as ex:
                     yield Item(name, "error", ex)
+
+        if unused_json:
+            warn_pack(f"Pack contains unused json: {unused_json}.", path)
 
 
 class _CollectLua(t.Generic[APath]):

--- a/pack_checker/collect.py
+++ b/pack_checker/collect.py
@@ -16,7 +16,7 @@ Item = namedtuple("Item", "name type data")
 
 
 def find_entry_point(path: Path, checks: t.Mapping[str, bool]) -> ZipPath:
-    from .cli import warn
+    from .warnings import warn_pack
 
     assert path.is_file()  # noqa: S101 debug message, would fail in the line below anyway
     zippath = ZipPath(path)
@@ -41,7 +41,7 @@ def find_entry_point(path: Path, checks: t.Mapping[str, bool]) -> ZipPath:
         # use directory instead of root
         zippath = candidates[0]
     if warn_for_hidden_files and hidden:
-        warn(f"Zip contains hidden files: {hidden}.", path)
+        warn_pack(f"Zip contains hidden files: {hidden}.", path)
     return zippath
 
 
@@ -127,7 +127,7 @@ class _CollectJson(t.Generic[APath]):
         self.path = path
 
     def __call__(self, checks: t.Mapping[str, bool]) -> t.Generator[Item, None, None]:
-        from .cli import warn
+        from .warnings import warn_pack
 
         path = self.path
         manifest, variants = read_manifest(path)
@@ -138,7 +138,7 @@ class _CollectJson(t.Generic[APath]):
             bin_read = "r" if PY < (3, 9) and isinstance(path, ZipPath) else "rb"
             with f.open(mode=bin_read) as bin_stream:
                 if bin_stream.read(3) == b"\xef\xbb\xbf":
-                    warn("File contains BOM but JSON files should not.", f, 0)
+                    warn_pack("File contains BOM but JSON files should not.", f, 0)
                 else:
                     bin_stream.seek(0, os.SEEK_SET)
                 pos = 0
@@ -146,13 +146,13 @@ class _CollectJson(t.Generic[APath]):
                     block = bin_stream.read(4096)
                     assert isinstance(block, bytes)  # noqa: S101 for type checker
                     if not block:
-                        warn("JSON files appears to be empty.", f, 0)
+                        warn_pack("JSON files appears to be empty.", f, 0)
                         break
                     orig_block_len = len(block)
                     block = block.lstrip()
                     if block:
                         if block[0:1] != b"[" and block[0:1] != b"{":
-                            warn(
+                            warn_pack(
                                 "JSON files should only contain white space before '[' or '{' for best compatibility."
                                 f" Byte at {pos + orig_block_len - len(block)} is {block[0:1]!r}.",
                                 f,
@@ -178,7 +178,7 @@ class _CollectLua(t.Generic[APath]):
         self.path = path
 
     def __call__(self, checks: t.Mapping[str, bool]) -> t.Generator[Item, None, None]:
-        from .cli import warn
+        from .warnings import warn_pack
 
         path = self.path
 
@@ -187,7 +187,7 @@ class _CollectLua(t.Generic[APath]):
             bin_read = "r" if PY < (3, 9) and isinstance(path, ZipPath) else "rb"
             with f.open(mode=bin_read) as bin_stream:
                 if bin_stream.read(3) == b"\xef\xbb\xbf":
-                    warn("File contains BOM but Lua files should not.", f, 0, 0)
+                    warn_pack("File contains BOM but Lua files should not.", f, 0, 0)
 
             with f.open(encoding="utf-8-sig") as stream:  # type: ignore[call-arg, unused-ignore]
                 try:
@@ -203,7 +203,7 @@ class _CollectImages(t.Generic[APath]):
         self.path = path
 
     def __call__(self, checks: t.Mapping[str, bool]) -> t.Generator[Item, None, None]:
-        from .cli import warn
+        from .warnings import warn_pack
 
         path = self.path
         patterns = sorted(set(ext for fmt in img_formats for ext in fmt.extensions))
@@ -236,9 +236,9 @@ class _CollectImages(t.Generic[APath]):
                             raise Exception("Did not match any format. Bad pattern?")
                         ext = "." + str(f).rsplit(".", 1)[-1]
                         if data_format is None:
-                            warn(f"Image is named {ext} ({ext_format.name}) but content does not match", f)
+                            warn_pack(f"Image is named {ext} ({ext_format.name}) but content does not match", f)
                         else:
-                            warn(
+                            warn_pack(
                                 f"Image is named {ext} ({ext_format.name}) "
                                 f"but content appears to be {data_format.name}",
                                 f,

--- a/pack_checker/collect.py
+++ b/pack_checker/collect.py
@@ -84,6 +84,8 @@ def identify_json(name: str, stream: t.TextIO, variants: t.List[str]) -> t.Optio
         return Item(name, "settings", data)
     if name == "manifest.json":
         return Item(name, "manifest", data)
+    if name == "versions.json":
+        return Item(name, "versions", data)  # TODO: warn if this file is present in the ZIP
     if name == ".luarc.json":
         return Item(name, ".luarc", data)
     for variant in variants:

--- a/pack_checker/collect.py
+++ b/pack_checker/collect.py
@@ -77,6 +77,8 @@ def identify_json(name: str, stream: t.TextIO, variants: t.List[str]) -> t.Optio
         return Item(name, "settings", data)
     if name == "manifest.json":
         return Item(name, "manifest", data)
+    if name == ".luarc.json":
+        return Item(name, ".luarc", data)
     for variant in variants:
         if variant:
             variant = variant + "/"

--- a/pack_checker/warnings.py
+++ b/pack_checker/warnings.py
@@ -1,0 +1,70 @@
+import contextlib
+import os
+import typing as t
+import warnings
+from pathlib import Path
+
+from .ziputil import ZipPath
+
+
+class PackWarning(UserWarning):
+    pass
+
+
+@contextlib.contextmanager
+def cli_warnings_formatter_context() -> t.Generator[None, None, None]:
+    original_formatter = warnings.formatwarning
+
+    def custom_formatter(
+        message: t.Union[Warning, str],
+        category: t.Type[Warning],
+        filename: str,
+        lineno: int,
+        line: t.Optional[str] = None,
+    ) -> str:
+        if category == PackWarning:
+            return f"{message}\n"
+        if category == RuntimeWarning:
+            return f"Runtime Warning: {message}\n"
+        return original_formatter(message, category, filename, lineno, line)
+
+    warnings.formatwarning = custom_formatter
+    yield
+    warnings.formatwarning = original_formatter
+
+
+if "CI" not in os.environ or not os.environ["CI"]:
+
+    def warn_pack(message: str, filename: t.Any = None, row: t.Optional[int] = None, col: int = 0) -> None:
+        if filename is not None and row is not None:
+            warnings.warn(f"{filename}[{row}:{col}]: {message}", PackWarning, stacklevel=2)
+        elif filename is not None:
+            warnings.warn(f"{filename}: {message}", PackWarning, stacklevel=2)
+        else:
+            warnings.warn(message, PackWarning, stacklevel=2)
+
+else:
+
+    def warn_pack(message: str, filename: t.Any = None, row: t.Optional[int] = None, col: int = 0) -> None:
+        physical_filename: t.Optional[str]
+        message_file_marker: str
+        if filename is not None:
+            message_file_marker = f"%0Ain {filename}"
+            if row is not None:
+                message_file_marker += f" at {col}:{row}"
+            if isinstance(filename, (str, Path)) and os.path.exists(filename):
+                physical_filename = str(filename)
+            elif isinstance(filename, ZipPath) and os.path.exists(str(getattr(filename, "root"))):
+                physical_filename = str(getattr(filename, "root"))
+                row = None
+            else:
+                physical_filename = None
+        else:
+            physical_filename = None
+            message_file_marker = ""
+        if physical_filename and row is not None:
+            print(f"::warning file={filename},line={row},col={col}::{message}{message_file_marker}")
+        elif physical_filename:
+            print(f"::warning file={filename}::{message}{message_file_marker}")
+        else:
+            print(f"::warning::{message}{message_file_marker}")

--- a/pack_checker/warnings.py
+++ b/pack_checker/warnings.py
@@ -36,6 +36,8 @@ def cli_warnings_formatter_context() -> t.Generator[None, None, None]:
 if "CI" not in os.environ or not os.environ["CI"]:
 
     def warn_pack(message: str, filename: t.Any = None, row: t.Optional[int] = None, col: int = 0) -> None:
+        if filename is not None:
+            filename = str(filename).rstrip("/")
         if filename is not None and row is not None:
             warnings.warn(f"{filename}[{row}:{col}]: {message}", PackWarning, stacklevel=2)
         elif filename is not None:
@@ -49,6 +51,7 @@ else:
         physical_filename: t.Optional[str]
         message_file_marker: str
         if filename is not None:
+            filename = str(filename).rstrip("/")
             message_file_marker = f"%0Ain {filename}"
             if row is not None:
                 message_file_marker += f" at {col}:{row}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ line-length = 120
 [tool.flake8]
 doctests = true
 max-line-length = 120
-max-complexity = 46  # TODO: get this down to ~15 by replacing cli.check() with a class
+max-complexity = 47  # TODO: get this down to ~15 by replacing cli.check() with a class
 extend-ignore = "E2,E3"  # may be incompatible to black, but also we use black anyway
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ line-length = 120
 [tool.flake8]
 doctests = true
 max-line-length = 120
-max-complexity = 41  # TODO: get this down to ~15
+max-complexity = 42  # TODO: get this down to ~15 by replacing cli.check() with a class
 extend-ignore = "E2,E3"  # may be incompatible to black, but also we use black anyway
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ line-length = 120
 [tool.flake8]
 doctests = true
 max-line-length = 120
-max-complexity = 42  # TODO: get this down to ~15 by replacing cli.check() with a class
+max-complexity = 46  # TODO: get this down to ~15 by replacing cli.check() with a class
 extend-ignore = "E2,E3"  # may be incompatible to black, but also we use black anyway
 
 [tool.ruff]

--- a/tests/collect/test_identify_json.py
+++ b/tests/collect/test_identify_json.py
@@ -32,3 +32,9 @@ class TestIdentifyJson(TestCase):
     def test_not_identify_luarc_json_subfolder(self) -> None:
         # we don't care about it outside of pack root
         self.assertIsNone(identify_json("var1/.luarc.json", StringIO("{}"), ["var1"]))
+
+    def test_ignore_vs_json(self) -> None:
+        self.assert_is_type("ignore", identify_json(".vs/test.json", StringIO("{}"), [""]))
+
+    def test_ignore_vscode_json(self) -> None:
+        self.assert_is_type("ignore", identify_json(".vscode/test.json", StringIO("{}"), [""]))

--- a/tests/collect/test_identify_json.py
+++ b/tests/collect/test_identify_json.py
@@ -25,3 +25,10 @@ class TestIdentifyJson(TestCase):
 
     def test_identify_var_classes_file_json(self) -> None:
         self.assert_is_type("classes", identify_json("var1/classes/some.json", StringIO("{}"), ["var1"]))
+
+    def test_identify_luarc_json(self) -> None:
+        self.assert_is_type(".luarc", identify_json(".luarc.json", StringIO("{}"), [""]))
+
+    def test_not_identify_luarc_json_subfolder(self) -> None:
+        # we don't care about it outside of pack root
+        self.assertIsNone(identify_json("var1/.luarc.json", StringIO("{}"), ["var1"]))

--- a/tests/collect/test_identify_json.py
+++ b/tests/collect/test_identify_json.py
@@ -38,3 +38,10 @@ class TestIdentifyJson(TestCase):
 
     def test_ignore_vscode_json(self) -> None:
         self.assert_is_type("ignore", identify_json(".vscode/test.json", StringIO("{}"), [""]))
+
+    def test_identify_versions_json(self) -> None:
+        self.assert_is_type("versions", identify_json("versions.json", StringIO("{}"), [""]))
+
+    def test_not_identify_versions_json_subfolder(self) -> None:
+        # we don't care about it outside of pack root (for now)
+        self.assertIsNone(identify_json("var1/versions.json", StringIO("{}"), ["var1"]))


### PR DESCRIPTION
Also make CLI output for warnings nicer.

Closes #22, Closes #30 and Closes #31.

* rename .cli.warn to .warnings.warn_pack
* warn_pack instead of print for unmatched files
* Runtime warning instead of print for unknown schema
* rework printing of warnings in run() to be nicer
* add support for "external schema"
* add `--validate-external` switch to allow validation with external schema (will become default in the future)
* validate luarc with external schema
* special item type "ignore" that is applied to json files in .vs/ and .vscode/ folders
  * those now only get warnings for being "hidden files" when checked as release (ZIP)
* similar to luarc, also validate versions.json
* add warning for "unused files" (like "hidden files") for versions.json in a release (ZIP)