### PR TITLE
CI: update action-gh-release to v3.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,7 @@ jobs:
           skip-decompress: true  # they should not have been compressed by upload-artifact
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')  # only create release on tag pushes
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           draft: true
           name: pack-checker v${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
This is the same version we use for PopTracker and was reviewed/tested there.